### PR TITLE
FIX:timestampのバグによるエラーを回避

### DIFF
--- a/gopro2gpx/fourCC.py
+++ b/gopro2gpx/fourCC.py
@@ -79,7 +79,11 @@ class Label_TypeUTimeStamp(LabelBase):
 		s = klvdata.rawdata.decode('utf-8', errors='replace')
 		# 'yymmddhhmmss.ffffff'
 		fmt = '%y%m%d%H%M%S.%f'
-		return datetime.strptime(s, fmt)
+		try:
+			s_datetime = datetime.strptime(s, fmt)
+		except:
+			s_datetime = datetime.strptime("111111111111.111", fmt)
+		return s_datetime
 
 class LabelDVID(LabelBase):
 	def __init__(self):


### PR DESCRIPTION
time stampのformatが間違っていることによるエラーを回避
time stampに固定値を埋め込む