### PR TITLE
FIX:データ破損時にNoneで返す

### DIFF
--- a/gopro2gpx/fourCC.py
+++ b/gopro2gpx/fourCC.py
@@ -135,7 +135,11 @@ class LabelXYZData(LabelBase):
 		# we need to process the SCAL value to measure properly the DATA
 		stype = map_type(klvdata.type)
 		s = struct.Struct('>' + stype*3)
-		data = XYZData._make(s.unpack_from(klvdata.rawdata))
+		if klvdata.rawdata is not None:
+			data = XYZData._make(s.unpack_from(klvdata.rawdata))
+		else:
+			data = None
+
 		return(data)
 
 class LabelACCL(LabelXYZData):


### PR DESCRIPTION
オーバーヒート時に一部のデータがNoneTypeになることによるエラーを防ぐ。